### PR TITLE
Storage get count

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,4 @@
 # This file lists all individuals having contributed content to the repository.
 
 
-Jennifer Huang <133@holbertonschool.com>
-Alexa Orrico <210@holbertonschool.com>
-Joann Vuong <130@holbertonschool.com> 
+Olayiwola Yunus Abayomi<bayoolayiwola0@gmail.com>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The console is the first segment of the AirBnB project at Holberton School that 
 This project is interpreted/tested on Ubuntu 14.04 LTS using python3 (version 3.4.3)
 
 ## Installation
-* Clone this repository: `git clone "https://github.com/alexaorrico/AirBnB_clone.git"`
+* Clone this repository: `git clone "https://github.com/Yuntech1/AirBnB_clone.git"`
 * Access AirBnb directory: `cd AirBnB_clone`
 * Run hbnb(interactively): `./console` and enter command
 * Run hbnb(non-interactively): `echo "<command>" | ./console.py`
@@ -154,8 +154,8 @@ EOF  all  create  destroy  help  quit  show  update
 No known bugs at this time. 
 
 ## Authors
-Alexa Orrico - [Github](https://github.com/alexaorrico) / [Twitter](https://twitter.com/alexa_orrico)  
-Jennifer Huang - [Github](https://github.com/jhuang10123) / [Twitter](https://twitter.com/earthtojhuang)
+Olayiwola Yunus Abayomi- [Github](https://github.com/Yuntech1) / [Twitter](https://twitter.com/bayohorlayiwola)  
+Ayodele  - [Github](https://github.com/) / [Twitter](https://twitter.com/)
 
 Second part of Airbnb: Joann Vuong
 ## License

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -86,3 +86,31 @@ class TestFileStorage(unittest.TestCase):
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_save(self):
         """Test that save properly saves objects to file.json"""
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_get(self):
+        """ Tests method for obtaining an instance db storage"""
+        storage = DBStorage
+        storage.reload()
+        dic = {"name": "Cundinamarca"}
+        instance = State(**dic)
+        storage.new(instance)
+        storage.save()
+        get_instance = storage.get(State, instance.id)
+        self.assertEqual(get_instance, instance)
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_count(self):
+        """ Tests count method db storage """
+        storage = DBStorage
+        storage.reload()
+        dic = {"name": "Vecindad"}
+        state = State(**dic)
+        storage.new(state)
+        dic = {"name": "Mexico", "state_id": state.id}
+        city = City(**dic)
+        storage.new(city)
+        storage.save()
+        c = storage.count()
+        self.assertEqual(len(storage.all()), c)
+

--- a/tests/test_models/test_engine/test_file_storage.py
+++ b/tests/test_models/test_engine/test_file_storage.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/python3
 """
 Contains the TestFileStorageDocs classes
@@ -113,3 +114,31 @@ class TestFileStorage(unittest.TestCase):
         with open("file.json", "r") as f:
             js = f.read()
         self.assertEqual(json.loads(string), json.loads(js))
+
+    @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
+    def test_get(self):
+        """ Tests method to obtain an instance file storage"""
+        self.storage = FileStorage()
+        self.storage.reload()
+        dic = {"name": "Vecindad"}
+        instance = State(**dic)
+        self.storage.new(instance)
+        self.storage.save()
+        self.storage = FileStorage()
+        get_instance = self.storage.get(State, instance.id)
+        self.assertEqual(get_instance, instance)
+
+    @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
+    def test_count(self):
+        """ Tests count method file storage """
+        self.storage = FileStorage()
+        self.storage.reload()
+        dic = {"name": "Dallas"}
+        state = State(**dic)
+        self.storage.new(state)
+        dic = {"name": "New"}
+        city = City(**dic)
+        self.storage.new(city)
+        self.storage.save()
+        c = self.storage.count()
+        self.assertEqual(len(self.storage.all()), c)


### PR DESCRIPTION
This pull request adds two new methods to the DBStorage and FileStorage classes: get() and count().

The get() method retrieves an object based on its class and ID, returning None if not found.
The count() method counts the number of objects in storage, optionally filtered by class.
Additionally, new tests have been added to ensure the functionality of these methods.