### PR TITLE
Storage get count

### DIFF
--- a/models/engine/db_storage.py
+++ b/models/engine/db_storage.py
@@ -74,3 +74,27 @@ class DBStorage:
     def close(self):
         """call remove() method on the private session attribute"""
         self.__session.remove()
+
+    def get(self, cls, id):
+        """
+        A method to retrieve one object
+        cls: class
+        id: string representing the object ID
+        """
+        if cls in classes.values() and id and type(id) == str:
+            d_obj = self.all(cls)
+            for key, value in d_obj.items():
+                if key.split(".")[1] == id:
+                    return value
+        return None
+
+    def count(self, cls=None):
+        """
+        A method to count the number of objects in storage
+        cls: class (optional)
+        Returns the number of objects in storage matching the given class
+        """
+        data = self.all(cls)
+        if cls in classes.values():
+            data = self.all(cls)
+        return len(data)

--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -44,7 +44,7 @@ class FileStorage:
         """serializes __objects to the JSON file (path: __file_path)"""
         json_objects = {}
         for key in self.__objects:
-            json_objects[key] = self.__objects[key].to_dict()
+            json_objects[key] = self.__objects[key].to_dict(False)
         with open(self.__file_path, 'w') as f:
             json.dump(json_objects, f)
 
@@ -55,7 +55,7 @@ class FileStorage:
                 jo = json.load(f)
             for key in jo:
                 self.__objects[key] = classes[jo[key]["__class__"]](**jo[key])
-        except:
+        except Exception as ex:
             pass
 
     def delete(self, obj=None):
@@ -68,3 +68,28 @@ class FileStorage:
     def close(self):
         """call reload() method for deserializing the JSON file to objects"""
         self.reload()
+
+    def get(self, cls, id):
+        """
+        A method to retrieve one object
+        cls: class
+        id: string representing the object ID
+        Returns the object based on the class and its ID, or None if not found
+        """
+        if cls in classes.values() and id and type(id) == str:
+            d_obj = self.all(cls)
+            for key, value in d_obj.items():
+                if key.split(".")[1] == id:
+                    return value
+        return None
+
+    def count(self, cls=None):
+        """
+        A method to count the number of objects in storage
+        cls: class (optional)
+        Returns the number of objects in storage matching the given class
+        """
+        data = self.all(cls)
+        if cls in classes.values():
+            data = self.all(cls)
+        return len(data)

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -68,21 +68,96 @@ test_db_storage.py'])
                             "{:s} method needs a docstring".format(func[0]))
 
 
-class TestFileStorage(unittest.TestCase):
-    """Test the FileStorage class"""
+def test_dbs_func_docstrings(self):
+        self.assertTrue(len(func[1].__doc__) >=1,
+                "{:s} method needs a docstring".format([0]))
+class TestDBStorage(unittest.Testcase):
+    """Test the file storage class"""
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_all_returns_dict(self):
-        """Test that all returns a dictionaty"""
-        self.assertIs(type(models.storage.all()), dict)
+        """test that all returns a dictionary"""
+        self.assertIs(type(models.storage.all(), dict)
 
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_all_no_class(self):
         """Test that all returns all rows when no class is passed"""
+        state_data = {"name": "Kigali"}
+        new_state = State(**state_data)
+        models.storage.new(new_state)
+        models.storage.save()
+
+        session = models.storage._DBStorage_session
+        all_objects = session.query(State).all()
+
+        self.assertTrue(len(all_objects > 0))
 
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_new(self):
-        """test that new adds an object to the database"""
+        """test that new adds to the database"""
+        state_data = {"name": "Nyagatare"}
+        new_state = State(**state_data)
 
-    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+        models.storage.new(new_state)
+        session = models.storage._DBStorage_session
+        retrieved_state = session.query(State).filter_by(id=new_state).first()
+        self.assertEqual(retrieved_state.id, new_state.id)
+        self.assertEqual(retrieved_stae.name, new_state.name)
+        self.assertIsNone(retrieved_state)
+
+    @untitest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_save(self):
         """Test that save properly saves objects to file.json"""
+        state_data = {"name": "Nevada"}
+        new_state = State(**state_data)
+
+        models.storage.new(new_state)
+        models.storage.save()
+
+        session = models.storage._DBStorage_session
+
+        retrieved_state = session.query(State).filter_by(id_new_state).first()
+
+        self.assertEqual(retrieved_state.id, new_state.id)
+        self.assertEqual(retrieved_stae.name, new_state.name)
+        self.assertIsNone(retrieved_state)
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_get(self):
+        """Tests method for obtaining an instance db storage"""
+        stroge = models.storage
+
+        storage.reload()
+
+        state_data = {"name": "Manhatan"}
+        state_instance = State(**state_data)
+        storage.new(state_instance)
+        storage.save()
+
+        retrieved_state = storage.get(State, state_instatce.id)
+
+        self.assertEqual(state_instance, retriieve_state)
+
+        fake_state_id = storage.get(State, 'fake_id')
+
+        self.assertEqual(fake_state_id, None)
+
+    @unitest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_count(self):
+        storage = models.storage
+        storage.reload()
+        state_data = {"name": "NewJasay"}
+        state_instatce = State(**state_data)
+        storage.new(state_instance)
+
+        city_data = {"naame": "Ohao", "state_id": state_instance_id}
+
+        city_instance = City(**city_data)
+
+        storage.new(city_instance)
+        storage.save()
+
+        state_occurrence = storage.count()
+        self.assertEqual(state_occurrence, len(storage.all(State)))
+
+        all_occurrence = storage.count()
+        self.assertEqual(state_occurrence, len(storage.all()))

--- a/tests/test_models/test_engine/test_file_storage.py
+++ b/tests/test_models/test_engine/test_file_storage.py
@@ -96,7 +96,8 @@ class TestFileStorage(unittest.TestCase):
 
     @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
     def test_save(self):
-        """Test that save properly saves objects to file.json"""
+        """
+        //Test that save properly saves objects to file.json//
         storage = FileStorage()
         new_dict = {}
         for key, value in classes.items():
@@ -113,3 +114,68 @@ class TestFileStorage(unittest.TestCase):
         with open("file.json", "r") as f:
             js = f.read()
         self.assertEqual(json.loads(string), json.loads(js))
+        """
+        @untitest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_save(self):
+        """
+        Test that save properly saves objects to file.json
+        """
+        state_data = {"name": "Nevada"}
+        new_state = State(**state_data)
+
+        models.storage.new(new_state)
+        models.storage.save()
+
+        session = models.storage._DBStorage_session
+
+        retrieved_state = session.query(State).filter_by(id_new_state).first()
+
+        self.assertEqual(retrieved_state.id, new_state.id)
+        self.assertEqual(retrieved_stae.name, new_state.name)
+        self.assertIsNone(retrieved_state)
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_get(self):
+        """
+        Tests method for obtaining an instance db storage
+        Testing the real retrieval
+        """
+        stroge = FileStorage()
+
+        storage.reload()
+
+        state_data = {"name": "Manhatan"}
+        state_instance = State(**state_data)
+
+        retrieved_state = storage.get(State, state_instatce.id)
+
+        self.assertEqual(state_instance, retriieve_state)
+
+        fake_state_id = storage.get(State, 'fake_id')
+
+        self.assertEqual(fake_state_id, None)
+
+    @unitest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_count(self):
+        """
+        Testing the count founction
+        To test if the count counts the real number
+        """
+        storage = FileStorage()
+        storage.reload()
+        state_data = {"name": "NewJasay"}
+        state_instatce = State(**state_data)
+        storage.new(state_instance)
+
+        city_data = {"naame": "Ohao", "state_id": state_instance_id}
+
+        city_instance = City(**city_data)
+
+        storage.new(city_instance)
+        storage.save()
+
+        state_occurrence = storage.count()
+        self.assertEqual(state_occurrence, len(storage.all(State)))
+
+        all_occurrence = storage.count()
+        self.assertEqual(state_occurrence, len(storage.all()))


### PR DESCRIPTION
Update DBStorage and FileStorage, adding two new methods. All changes done in the branch storage_get_count:

A method to retrieve one object:

Prototype: def get(self, cls, id):
cls: class
id: string representing the object ID
Returns the object based on the class and its ID, or None if not found
A method to count the number of objects in storage:

Prototype: def count(self, cls=None):
cls: class (optional)
Returns the number of objects in storage matching the given class. If no class is passed, returns the count of all objects in storage.
Added two new tests for these 2 methods on each storage engine.
